### PR TITLE
Reversal is not a justification, it already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,12 @@ The syntax is also much shorter and more ergonomic than a function
 call.
 
 The step argument is useful for patterns like creating a slice with
-every other element in an array or for reversing an array.
+every other element in an array.
 
 ```js
-const arr = ['a', 'b', 'c', 'd'];
+const arr = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 arr[1:4:2];
 // → ['b', 'd']
-
-arr[::-1];
-// → ['d', 'c', 'b', 'a']
 ```
 
 The step argument also makes it really easy to work with matrices.


### PR DESCRIPTION
Reversal of an array can easily, and more explicitly, be done with `array.reverse()`. The purpose of this **slice notation** is to make things easier or more simple for the users, not more confusing, whereas, `array.reverse()` is expressive and helps people understand what's going on in the code.

Would resolve #22 